### PR TITLE
GH-10 Add task for inspect project dependencies in multi-module builds

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- (GH-10) Add "dependencProjectReport" task to allow finding dependency instances specifically of projects in the same multi-module configuration
 
 ## [0.1.0]
 - Create a plug-in which adds standard behavior for creating a merged code coverage report

--- a/doc/dependency-insight.md
+++ b/doc/dependency-insight.md
@@ -25,17 +25,24 @@ Two tasks are provided by the plug-in:
 
 ### dependencyReport
 
-Applies Gradle's [DependencyReportTask](https://docs.gradle.org/3.4.1/dsl/org.gradle.api.tasks.diagnostics.DependencyReportTask.html), allowing output of the full dependency tree of the project(s)
+Applies Gradle's [DependencyReportTask](https://docs.gradle.org/3.2.1/dsl/org.gradle.api.tasks.diagnostics.DependencyReportTask.html), allowing output of the full dependency tree of the project(s)
 
 ### dependencyInsightReport
 
-Applies Gradle's [DependencyInsightReportTask](https://docs.gradle.org/3.4.1/dsl/org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.html), which allows determination of where a dependency is introduced. Takes two arguments
+Applies Gradle's [DependencyInsightReportTask](https://docs.gradle.org/3.2.1/dsl/org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.html), which allows determination of where a dependency is introduced. Takes two arguments
 
 * `--configuration`
     * The Gradle configuration to search for instances of the given dependency in. (Ex: `runtime`)
 * `--dependency`
     * All or part of the dependency name to find (Ex: `org.testng`, `testng`)
+    
+### dependencyProjectReport
 
+Applies Gradle's [DependencyInsightReportTask](https://docs.gradle.org/3.2.1/dsl/org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.html), with a matching specification configured to match any projects in a multi-module environment
+
+* `--configuration`
+    * The Gradle configuration to search for instances of the given dependency in. (Ex: `runtime`)
+    
 ## Replaced Boilerplate
 
 The plug-in has the effect of replacing the boilerplate:
@@ -44,4 +51,8 @@ The plug-in has the effect of replacing the boilerplate:
 task dependencyReport(type: DependencyReportTask) {}
 
 task dependencyInsightReport(type: DependencyInsightReportTask) {}
+
+task dependencyProjectReport(type: DependencyInsightReportTask) {
+    spec = new ProjectDependencyResultSpec(project)
+}
 ```

--- a/flare-ops-gradle-test/build.gradle
+++ b/flare-ops-gradle-test/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'org.starchartlabs.flare', name: 'flare-operations-plugins', version: '0.1.0-SNAPSHOT', changing: true
+        classpath group: 'org.starchartlabs.flare', name: 'flare-operations-plugins', version: '0.2.0-SNAPSHOT', changing: true
     }
 }
 

--- a/flare-ops-gradle-test/flare-test-subproject2/build.gradle
+++ b/flare-ops-gradle-test/flare-test-subproject2/build.gradle
@@ -1,3 +1,4 @@
 dependencies{
+    compile project(':flare-test-subproject1')
     testCompile group: 'org.testng', name: 'testng', version: '6.9.10'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Application Versions
-version=0.1.1-SNAPSHOT
+version=0.2.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 javaVersion=1.8

--- a/src/main/groovy/org/starchartlabs/flare/operations/dsl/ProjectDependencyResultSpec.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/operations/dsl/ProjectDependencyResultSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Aug 23, 2018 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.flare.operations.dsl;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.specs.Spec;
+
+/**
+ * Dependency matching specification which is designed to only match against other projects/modules in the same multi-module system as the provided project
+ *
+ * <p>
+ * Heavily based on default Gradle <a href="https://github.com/gradle/gradle/blob/master/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java">"DependencyResultSpec"</a>
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class ProjectDependencyResultSpec implements Spec<DependencyResult> {
+
+    private final Set<String> projectIdentifiers
+
+    private final Project project
+
+    public ProjectDependencyResultSpec(Project project) {
+        this.project = project
+        projectIdentifiers = new HashSet<>();
+
+        project.rootProject.allprojects{p ->
+            projectIdentifiers.add(p.path)
+
+            project.getLogger().debug("Adding path ${p.path} to search configuration of project ${project.path}")
+        }
+    }
+
+    @Override
+    public boolean isSatisfiedBy(DependencyResult candidate) {
+        if (candidate instanceof ResolvedDependencyResult) {
+            return matchesRequested(candidate) || matchesSelected((ResolvedDependencyResult) candidate);
+        } else {
+            return matchesRequested(candidate);
+        }
+    }
+
+    private boolean matchesRequested(DependencyResult candidate) {
+        ComponentSelector requested = candidate.getRequested();
+
+        if (requested instanceof ModuleComponentSelector) {
+            ModuleComponentSelector requestedModule = (ModuleComponentSelector) requested
+            String requestedCandidate = "${requestedModule.group}:${requestedModule.module}:${requestedModule.version}"
+
+            project.getLogger().debug("Comparing DependencyResult ${requestedCandidate} to known projects")
+
+            return projectIdentifiers.any{ p -> requestedCandidate.contains(p) }
+        }
+
+        return false;
+    }
+
+    private boolean matchesSelected(ResolvedDependencyResult candidate) {
+        ModuleVersionIdentifier selected = candidate.getSelected().getModuleVersion();
+        String selectedCandidate = "${selected.group}:${selected.name}:${selected.version}"
+
+        project.getLogger().debug("Comparing ResolvedDependencyResult ${selectedCandidate}  to known projects")
+
+        return projectIdentifiers.any{ p -> selectedCandidate.contains(p) }
+    }
+}

--- a/src/main/groovy/org/starchartlabs/flare/operations/plugin/DependencyInsightPlugin.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/operations/plugin/DependencyInsightPlugin.groovy
@@ -8,8 +8,10 @@ package org.starchartlabs.flare.operations.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask
 import org.gradle.api.tasks.diagnostics.DependencyReportTask
+import org.starchartlabs.flare.operations.dsl.ProjectDependencyResultSpec
 
 /**
  * Plug-in which applies tasks which allow inspection of dependency information
@@ -23,12 +25,21 @@ public class DependencyInsightPlugin implements Plugin<Project> {
 
     private static final String INSIGHT_TASK_NAME = 'dependencyInsightReport'
 
+    private static final String PROJECT_TASK_NAME = 'dependencyProjectReport'
+
     @Override
     public void apply(Project project) {
         //Task which will show what the dependency set of the project is in a tree form
-        project.getTasks().create(LIST_TASK_NAME, DependencyReportTask.class);
+        Task listTask = project.getTasks().create(LIST_TASK_NAME, DependencyReportTask.class);
+        listTask.description = 'Show the dependency set of the project in a tree form'
 
         //Task which will show what is introducing a particular dependency
-        project.getTasks().create(INSIGHT_TASK_NAME, DependencyInsightReportTask.class);
+        Task insightTask = project.getTasks().create(INSIGHT_TASK_NAME, DependencyInsightReportTask.class);
+        insightTask.description = 'Shows occurances of a particular dependency'
+
+        //Task which will show results filtered to project dependencies
+        DependencyInsightReportTask projectTask = project.getTasks().create(PROJECT_TASK_NAME, DependencyInsightReportTask.class);
+        projectTask.dependencySpec = new ProjectDependencyResultSpec(project)
+        projectTask.description = 'Shows dependencies on other projects in a multi-module environment'
     }
 }

--- a/src/test/java/org/starchartlabs/flare/test/operations/plugin/DependencyInsightPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/test/operations/plugin/DependencyInsightPluginTest.java
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradle.internal.impldep.org.testng.Assert;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.starchartlabs.flare.operations.dsl.ProjectDependencyResultSpec;
 import org.testng.annotations.Test;
 
 public class DependencyInsightPluginTest {
@@ -28,6 +29,11 @@ public class DependencyInsightPluginTest {
 
         Task dependencyInsightReport = project.getTasks().getByName("dependencyInsightReport");
         Assert.assertTrue(dependencyInsightReport instanceof DependencyInsightReportTask);
+
+        Task dependencyProjectReport = project.getTasks().getByName("dependencyProjectReport");
+        Assert.assertTrue(dependencyProjectReport instanceof DependencyInsightReportTask);
+        Assert.assertTrue(((DependencyInsightReportTask) dependencyProjectReport)
+                .getDependencySpec() instanceof ProjectDependencyResultSpec);
     }
 
 }


### PR DESCRIPTION
When working on larger multi-module Gradle projects, it would be useful
to have a way to inspect the current dependencies between the various
modules without manually drawing a graph.

Since Gradle is managing these relations, and has a pre-defined
precedent for providing dependency reporting, it makes sense to extend
the existing dependeny inspection methods to cover this use case