### PR TITLE
GH-9 Switch report destination argument to File object

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - (GH-10) Add "dependencProjectReport" task to allow finding dependency instances specifically of projects in the same multi-module configuration
+- (GH-9) Switch to passing report location as a file to try and use newer APIs when available
 
 ## [0.1.0]
 - Create a plug-in which adds standard behavior for creating a merged code coverage report

--- a/src/main/groovy/org/starchartlabs/flare/operations/task/MergeCoverageReportsTask.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/operations/task/MergeCoverageReportsTask.groovy
@@ -30,7 +30,7 @@ public class MergeCoverageReportsTask extends JacocoReport {
 
             reports {
                 xml.enabled true
-                xml.destination "${project.buildDir}/reports/jacoco/report.xml"
+                xml.destination project.file("${project.buildDir}/reports/jacoco/report.xml")
                 html.enabled false
                 csv.enabled false
             }


### PR DESCRIPTION
In version 4.0 of Gradle, the ConfigurableReport.setDestination method
was overloaded to accept either a generic Object or a File (previously,
only generic object was accepted). The original method was deprecated,
causing a warning to be printed when the merge coverage reports plug-in
is applied, as it configures the destination as a string.

This change switches to configuring the location as a File, which should
cause the newer method to be used when available