### PR TITLE
Resolves GH-20: Force correct report configuration for merge task

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - (GH-27) Update minimum required Gradle version to 4.0
+- (GH-20) Added workaround to force correct configuration of mergeCoverageReports task upon plug-in application
 
 ## [1.1.0]
 ### Changed

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -4,8 +4,23 @@
 
 No changes required - major version was a change to the implementing language
 
-## 1.x 2.x
+## 1.x to 2.x
 
 ### Required
 
 - Update to Gradle 4.x or later
+
+### Recommended
+
+- Remove workaround for GH-20:
+```
+mergeCoverageReports {
+    reports {
+        xml.enabled true
+        html.enabled false
+        csv.enabled false
+        
+        xml.destination = "${buildDir}/reports/jacoco/report.xml"
+    }
+}
+```

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/MergeCoverageReportsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/MergeCoverageReportsPlugin.java
@@ -13,7 +13,6 @@ package org.starchartlabs.flare.operations.plugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.testing.jacoco.tasks.JacocoReport;
 import org.starchartlabs.flare.operations.task.MergeCoverageReportsTask;
 
 /**
@@ -34,7 +33,10 @@ public class MergeCoverageReportsPlugin implements Plugin<Project> {
         project.getPluginManager().apply("base");
         project.getPluginManager().apply("jacoco");
 
-        JacocoReport mergeTask = project.getTasks().create(TASK_NAME, MergeCoverageReportsTask.class);
+        MergeCoverageReportsTask mergeTask = project.getTasks().create(TASK_NAME, MergeCoverageReportsTask.class);
+        // GH-20 For some reason, things like description stay after creation in constructor, but the reports object
+        // seems to be reset
+        mergeTask.configureReports();
 
         project.getTasks().getByName("check").dependsOn(mergeTask);
 

--- a/src/main/java/org/starchartlabs/flare/operations/task/MergeCoverageReportsTask.java
+++ b/src/main/java/org/starchartlabs/flare/operations/task/MergeCoverageReportsTask.java
@@ -10,6 +10,8 @@
  */
 package org.starchartlabs.flare.operations.task;
 
+import java.io.File;
+
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -52,11 +54,21 @@ public class MergeCoverageReportsTask extends JacocoReport {
             });
         });
 
-        getReports().getXml().setEnabled(true);
-        getReports().getXml().setDestination(
-                getProject().file(getProject().getBuildDir().toString() + "/reports/jacoco/report.xml"));
-        getReports().getHtml().setEnabled(false);
-        getReports().getCsv().setEnabled(false);
+        // GH-20 This doesn't seem to take effect, so the plug-in repeats it
+        configureReports();
+    }
+
+    // GH-20 Exposed to prevent duplicate definitions. Run by the plug-in (again) to workaround GH-20. Setting
+    // description in the constructor works, setting reports values doesn't
+    public void configureReports() {
+        reports(reports -> {
+            File destination = getProject().file(getProject().getBuildDir().toString() + "/reports/jacoco/report.xml");
+
+            reports.getXml().setEnabled(true);
+            reports.getXml().setDestination(destination);
+            reports.getHtml().setEnabled(false);
+            reports.getCsv().setEnabled(false);
+        });
     }
 
 }


### PR DESCRIPTION
This change set adds a workaround for a Gradle configuration issue,
where some configuration done in the constructor of the created task
would not apply. Settings would read correctly within the constructor,
but once back in the plug-in configuration, would read incorrectly.

This change adds re-configuration of these values at the plug-in
configuration level, forcing the intended configuration