### PR TITLE
Resolves GH-35: Adds a DSL for defining loadable credentials

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- (GH-35) Added ability to specify credentials and their load sources within Gradle builds
+
 ### Changed
 - (GH-33) Update minimum required Gradle version to 5.0
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Introduces standard tasks for viewing dependency information in multi-module pro
 
 See the [usage documentation](./docs/dependency-reporting.md) for information and requirements for applying the plug-in
 
+### org.starchartlabs.flare.managed-credentials
+
+Introduces standard domain-specific language to Gradle builds for defining credentials loaded during the build process
+
+See the [usage documentation](./docs/managed-credentials.md) for information and requirements for applying the plug-in
+
 ### org.starchartlabs.flare.dependency-insight
 
 *This plug-in is DEPRECATED - use `org.starchartlabs.flare.dependency-insight` instead*

--- a/docs/managed-credentials.md
+++ b/docs/managed-credentials.md
@@ -1,0 +1,70 @@
+# org.starchartlabs.flare.managed-credentials
+
+The `managed-credentials` plug-in is a configuration plug-in which adds a standard DSL extension `credentials` to describe credentials which may be laoded and used for build operations
+
+## Application
+
+Apply the plug-in via the buildscript classpath:
+
+```
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath group: 'org.starchartlabs.flare', name: 'flare-operations-plugins', version: '3.0.0'
+    }
+}
+
+apply plugin: 'org.starchartlabs.flare.managed-credentials'
+```
+
+## Use
+
+To specify the publication information, the DSL breaks down into 4 parts:
+
+```
+credentials {
+    example {
+        environment('ENV1', 'ENV2')
+        systemProperties('example_user', 'example_key')
+        defaultLogin('defaultuser', 'defaultpassword')
+    }
+}
+```
+
+Overall, this configures a set of credentials named `example` which attempt to load from environment variables, then tries system properties, and finally uses default credentials if both the environment variables and system properties were not present
+
+### example
+
+```
+example {
+  ...
+}
+```
+
+Named credential configuration. Allows referencing the built credentials via `credentials.example.username` and `credentials.example.password` within the build file
+
+### enviroment
+
+```
+environment('ENV1', 'ENV2')
+```
+
+Adds a load source for the `example` credentials - the username will be loaded from `ENV1`, and the password from `ENV2`
+
+### systemProperties
+
+```
+systemProperties('example_user', 'example_key')
+```
+
+Adds a load source for the `example` credentials - the username will be loaded from `example_user`, and the password from `example_key`
+
+### defaultLogin
+
+```
+defaultLogin('defaultuser', 'defaultpassword')
+```
+
+Adds a load source for the `example` credentials - the username will be `defaultuser`, and the password `defaultpassword`

--- a/flare-ops-gradle-test/build.gradle
+++ b/flare-ops-gradle-test/build.gradle
@@ -9,6 +9,17 @@ buildscript {
 }
 
 apply plugin: 'org.starchartlabs.flare.merge-coverage-reports'
+apply plugin: 'org.starchartlabs.flare.managed-credentials'
+
+credentials {
+    bintray {
+        environment('ENV1', 'ENV2')
+        systemProperties('bintray_user', 'bintray_key')
+        defaultLogin('defaultuser', 'defaultpassword')
+    }
+}
+
+println "${credentials.bintray.username}"
 
 allprojects{
     apply plugin: 'java'

--- a/src/main/java/org/starchartlabs/flare/operations/model/CredentialConfiguration.java
+++ b/src/main/java/org/starchartlabs/flare/operations/model/CredentialConfiguration.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.operations.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Named;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+
+/**
+ * Configuration for a single named set of credentials
+ *
+ * <p>
+ * Credentials may be drawn from sources such as environment variables, system properties, and other values provided by
+ * the build system. Configurations allow specification of an ordered list of source sto attempt to draw credentials
+ * from during a build, and access to the read credentials by the build system
+ *
+ * @author romeara
+ * @since 3.0.0
+ */
+public class CredentialConfiguration implements Named {
+
+    private String name;
+
+    private List<CredentialSource> sources;
+
+    private Credentials credentials;
+
+    public CredentialConfiguration(String name) {
+        this.name = Objects.requireNonNull(name);
+
+        sources = new ArrayList<>();
+        credentials = null;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public CredentialConfiguration configure(@DelegatesTo(CredentialConfiguration.class) Closure<CredentialConfiguration> closure) {
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    public String getUsername() {
+        return getCredentials().getUsername();
+    }
+
+    public String getPassword() {
+        return getCredentials().getPassword();
+    }
+
+    /**
+     * Allows reading credentials from environment variables
+     *
+     * @param usernameVariable
+     *            The name of the environment variable to read a username from
+     * @param passwordVariable
+     *            The name of the environment variable to read a password from
+     * @return This configuration representation
+     * @since 3.0.0
+     */
+    public CredentialConfiguration environment(String usernameVariable, String passwordVariable) {
+        sources.add(new EnvironmentCredentialSource(usernameVariable, passwordVariable));
+
+        return this;
+    }
+
+    /**
+     * Allows reading credentials from system properties
+     *
+     * @param usernameVariable
+     *            The name of the system property to read a username from
+     * @param passwordVariable
+     *            The name of the system property to read a password from
+     * @return This configuration representation
+     * @since 3.0.0
+     */
+    public CredentialConfiguration systemProperties(String usernameVariable, String passwordVariable) {
+        sources.add(new PropertyCredentialSource(usernameVariable, passwordVariable));
+
+        return this;
+    }
+
+    /**
+     * Allows reading credentials provided to the build system directly
+     *
+     * @param username
+     *            The username to assign to the credentials
+     * @param password
+     *            The password to assign to the credentials
+     * @return This configuration representation
+     * @since 3.0.0
+     */
+    public CredentialConfiguration defaultLogin(String username, String password) {
+        sources.add(new DefaultCredentialSource(username, password));
+
+        return this;
+    }
+
+    /**
+     * @return A loaded set of credentials from the first source which could provide them
+     */
+    private Credentials getCredentials() {
+        if (credentials == null) {
+            credentials = sources.stream()
+                    .map(CredentialSource::load)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst()
+                    .orElseThrow(() -> new GradleException(
+                            "Could not load '" + getName()
+                            + "' credentials - no sources provided a complete credential set"));
+        }
+
+        return credentials;
+    }
+
+    private static final class EnvironmentCredentialSource implements CredentialSource {
+
+        private final String usernameVariable;
+
+        private final String passwordVariable;
+
+        public EnvironmentCredentialSource(String usernameVariable, String passwordVariable) {
+            this.usernameVariable = Objects.requireNonNull(usernameVariable);
+            this.passwordVariable = Objects.requireNonNull(passwordVariable);
+        }
+
+        @Override
+        public Optional<Credentials> load() {
+            Credentials result = null;
+
+            String username = System.getenv(usernameVariable);
+            String password = System.getenv(passwordVariable);
+
+            if (username != null && password != null) {
+                result = new Credentials(username, password);
+            }
+
+            return Optional.ofNullable(result);
+        }
+
+    }
+
+    private static final class PropertyCredentialSource implements CredentialSource {
+
+        private final String usernameVariable;
+
+        private final String passwordVariable;
+
+        public PropertyCredentialSource(String usernameVariable, String passwordVariable) {
+            this.usernameVariable = Objects.requireNonNull(usernameVariable);
+            this.passwordVariable = Objects.requireNonNull(passwordVariable);
+        }
+
+        @Override
+        public Optional<Credentials> load() {
+            Credentials result = null;
+
+            String username = System.getProperty(usernameVariable);
+            String password = System.getProperty(passwordVariable);
+
+            if (username != null && password != null) {
+                result = new Credentials(username, password);
+            }
+
+            return Optional.ofNullable(result);
+        }
+
+    }
+
+    private static final class DefaultCredentialSource implements CredentialSource {
+
+        private final Credentials credentials;
+
+        public DefaultCredentialSource(String username, String password) {
+            this.credentials = new Credentials(username, password);
+        }
+
+        @Override
+        public Optional<Credentials> load() {
+            return Optional.of(credentials);
+        }
+    }
+
+
+}

--- a/src/main/java/org/starchartlabs/flare/operations/model/CredentialSource.java
+++ b/src/main/java/org/starchartlabs/flare/operations/model/CredentialSource.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.operations.model;
+
+import java.util.Optional;
+
+/**
+ * Represents an available mechanism to load a set of credentials
+ *
+ * @author romeara
+ * @since 3.0.0
+ */
+public interface CredentialSource {
+
+    /**
+     * @return Loaded credentials, or empty if either the username or password could not be loaded
+     * @since 3.0.0
+     */
+    Optional<Credentials> load();
+
+}

--- a/src/main/java/org/starchartlabs/flare/operations/model/Credentials.java
+++ b/src/main/java/org/starchartlabs/flare/operations/model/Credentials.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.operations.model;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Represents a loaded set of credentials for use by the build system
+ *
+ * @author romeara
+ * @since 3.0.0
+ */
+public class Credentials {
+
+    private final String username;
+
+    private final byte[] password;
+
+    public Credentials(String username, String password) {
+        this.username = Objects.requireNonNull(username);
+        this.password = Objects.requireNonNull(password.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return new String(password, StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/ManagedCredentialsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/ManagedCredentialsPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.operations.plugin;
+
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.starchartlabs.flare.operations.model.CredentialConfiguration;
+
+/**
+ * Configuration plug-in that adds structures for defining credentials which can be referenced throughout the build
+ * system
+ *
+ * @author romeara
+ * @since 3.0.0
+ */
+public class ManagedCredentialsPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        NamedDomainObjectContainer<CredentialConfiguration> credentials = project
+                .container(CredentialConfiguration.class, name -> {
+                    return new CredentialConfiguration(name);
+                });
+
+        project.getExtensions().add("credentials", credentials);
+    }
+
+}

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.managed-credentials.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.managed-credentials.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.operations.plugin.ManagedCredentialsPlugin

--- a/src/test/java/org/starchartlabs/flare/test/operations/plugin/ManagedCredentialsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/test/operations/plugin/ManagedCredentialsPluginIntegrationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.test.operations.plugin;
+
+import java.io.File;
+import java.net.URL;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ManagedCredentialsPluginIntegrationTest {
+
+    private File testProjectDirectory;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        URL directory = this.getClass().getClassLoader()
+                .getResource("org/starchartlabs/flare/test/managed/credentials");
+
+        testProjectDirectory = new File(directory.toURI());
+    }
+
+    @Test
+    public void appliesWithoutError() throws Exception {
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDirectory)
+                .withArguments("clean")
+                .build();
+
+        TaskOutcome outcome = result.task(":clean").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome) || TaskOutcome.UP_TO_DATE.equals(outcome));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/test/operations/plugin/ManagedCredentialsPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/test/operations/plugin/ManagedCredentialsPluginTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.test.operations.plugin;
+
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ManagedCredentialsPluginTest {
+
+    private static final String PLUGIN_ID = "org.starchartlabs.flare.managed-credentials";
+
+    private Project project;
+
+    @BeforeClass
+    public void setupProject() {
+        project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(PLUGIN_ID);
+    }
+
+    @Test
+    public void configurationApplied() throws Exception {
+        Object found = project.getExtensions().findByName("credentials");
+
+        Assert.assertNotNull(found);
+        Assert.assertTrue(found instanceof NamedDomainObjectContainer);
+    }
+
+}

--- a/src/test/resources/org/starchartlabs/flare/test/managed/credentials/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/test/managed/credentials/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'java'
+    id  'org.starchartlabs.flare.managed-credentials'
+}


### PR DESCRIPTION
Adds DSL to Gradle for defining credentials loadable from environment
variables, system properties, and default values. Sources have a defined
order per named set of credentials. Available sources are checked until
a source can provide both a username and password.

If no source can provide, the build will fail on the first attempt to
access the credentials (build sequences will not need to provide
credentials for task sets which do not reference the crdentials, unless
they are referenced in the configuration step_