### PR TITLE
Add deprecation warnings and links to migration guides for flare-plugins

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added deprecation warnings and migration information
 
 ## [3.0.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # flare-operations-plugins
 
+This project has been deprecated in favor of [flare-plugins](https://github.com/StarChart-Labs/flare-plugins) - see the [migration guide](https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md) for information on transitioning to the new plug-ins
+
 [![Travis CI](https://img.shields.io/travis/com/StarChart-Labs/flare-operations-plugins.svg?branch=master)](https://travis-ci.com/StarChart-Labs/flare-operations-plugins) [![Code Coverage](https://img.shields.io/codecov/c/github/StarChart-Labs/flare-operations-plugins.svg)](https://codecov.io/github/StarChart-Labs/flare-operations-plugins) [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/StarChart-Labs/flare-operations-plugins/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/StarChart-Labs/flare-operations-plugins/branches/master) [![Changelog validated by Chronicler](https://chronicler.starchartlabs.org/images/changelog-chronicler-success.png)](https://chronicler.starchartlabs.org/) [![Maven Central](https://img.shields.io/maven-central/v/org.starchartlabs.flare/flare-operations-plugins.svg)](https://mvnrepository.com/artifact/org.starchartlabs.flare/flare-operations-plugins) [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 * [Legal](#legal)

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyInsightPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyInsightPlugin.java
@@ -37,7 +37,7 @@ public class DependencyInsightPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getLogger().warn(
-                "The org.starchartlabs.flare.dependency-insight plug-in is deprecated. Switch to org.starchartlabs.flare.dependency-reporting");
+                "The org.starchartlabs.flare.dependency-insight plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
 
         // Task which will show what the dependency set of the project is in a tree form
         Task listTask = project.getTasks().create(LIST_TASK_NAME, DependencyReportTask.class);

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyReportingPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyReportingPlugin.java
@@ -37,6 +37,9 @@ public class DependencyReportingPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getLogger().warn(
+                "The org.starchartlabs.flare.dependency-reporting plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
+
         // Task which will show what the dependency set of the project is in a tree form
         Task listTask = project.getTasks().create(LIST_TASK_NAME, DependencyReportTask.class);
         listTask.setGroup("Help");

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyVersionsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/DependencyVersionsPlugin.java
@@ -20,6 +20,9 @@ public class DependencyVersionsPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getLogger().warn(
+                "The org.starchartlabs.flare.dependency-versions plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
+
         project.getExtensions().add("dependencyVersions", new DependencyVersions(project));
     }
 

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/IncreaseTestLoggingPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/IncreaseTestLoggingPlugin.java
@@ -21,6 +21,9 @@ public class IncreaseTestLoggingPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getLogger().warn(
+                "The org.starchartlabs.flare.increase-test-logging plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
+
         project.getPluginManager().withPlugin("java", plugin -> {
             TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
 

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/ManagedCredentialsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/ManagedCredentialsPlugin.java
@@ -22,6 +22,9 @@ public class ManagedCredentialsPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getLogger().warn(
+                "The org.starchartlabs.flare.managed-credentials plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
+
         NamedDomainObjectContainer<CredentialConfiguration> credentials = project
                 .container(CredentialConfiguration.class, name -> {
                     return new CredentialConfiguration(name);

--- a/src/main/java/org/starchartlabs/flare/operations/plugin/MergeCoverageReportsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/operations/plugin/MergeCoverageReportsPlugin.java
@@ -28,6 +28,9 @@ public class MergeCoverageReportsPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getLogger().warn(
+                "The org.starchartlabs.flare.merge-coverage-reports plug-in from flare-operations-plugins is deprecated. See migration guide at https://github.com/StarChart-Labs/flare-plugins/blob/master/docs/FLARE_OPERATIONS_MIGRATION.md");
+
         // Base: Provides build task, Java: Provides sourceSets (and sourceSets.main configuration), Jacoco: Provides
         // coverage instrumentation
         project.getPluginManager().apply("base");


### PR DESCRIPTION
With the release of flare-plugins 0.1.0, all use-cases from this project are covered. A final release will be done with deprecation warnings before archiving the repository.

This change set adds documentation, change logs, and deprecation logging for all plug-ins